### PR TITLE
docs: fix simple typo, envinronments -> environments

### DIFF
--- a/varnishtuner.py
+++ b/varnishtuner.py
@@ -492,7 +492,7 @@ def checkVitals(xvs, vc, si):
 	if not recommend:
 		msg_out("Nothing to report so far. Carry on!")
 		
-# dmidecode doesn't do much in VZ envinronments
+# dmidecode doesn't do much in VZ environments
 def isVZ():
 	unamecmd = """/bin/uname -a"""
 	unamep = Popen(unamecmd, shell=True, stdout=PIPE)


### PR DESCRIPTION
There is a small typo in varnishtuner.py.

Should read `environments` rather than `envinronments`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md